### PR TITLE
Add dedicated pattern detail view (closes #11)

### DIFF
--- a/frontend/public/locales/en/pattern.json
+++ b/frontend/public/locales/en/pattern.json
@@ -96,5 +96,8 @@
     "download": "Download",
     "not_available": "Not available",
     "close": "Close",
-    "files_upload_success": "Pattern and files uploaded successfully."
+    "files_upload_success": "Pattern and files uploaded successfully.",
+    "back_to_patterns": "Back to patterns",
+    "pattern_not_found": "Pattern not found.",
+    "open_url": "Open URL"
 }

--- a/frontend/public/locales/es/pattern.json
+++ b/frontend/public/locales/es/pattern.json
@@ -96,5 +96,8 @@
     "download": "Descargar",
     "not_available": "No disponible",
     "close": "Cerrar",
-    "files_upload_success": "Archivos y patrón subidos con éxito."
+    "files_upload_success": "Archivos y patrón subidos con éxito.",
+    "back_to_patterns": "Volver a patrones",
+    "pattern_not_found": "Patrón no encontrado.",
+    "open_url": "Abrir URL"
 }

--- a/frontend/src/components/Patterns/AddFiles.tsx
+++ b/frontend/src/components/Patterns/AddFiles.tsx
@@ -55,6 +55,7 @@ const AddFiles = ({ id, closeMenu }: { id: string, closeMenu?: () => void }) => 
         },
         onSettled: () => {
             queryClient.invalidateQueries({ queryKey: ["patterns"] })
+            queryClient.invalidateQueries({ queryKey: ["pattern"] })
         },
     })
 

--- a/frontend/src/components/Patterns/DeletePattern.tsx
+++ b/frontend/src/components/Patterns/DeletePattern.tsx
@@ -18,7 +18,7 @@ import {
 import useCustomToast from "@/hooks/useCustomToast"
 import { useTranslation } from 'react-i18next';
 
-const DeletePattern = ({ id }: { id: string }) => {
+const DeletePattern = ({ id, onSuccess }: { id: string; onSuccess?: () => void }) => {
   const [isOpen, setIsOpen] = useState(false)
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
@@ -38,6 +38,7 @@ const DeletePattern = ({ id }: { id: string }) => {
     onSuccess: () => {
       showSuccessToast(tPattern('pattern_delete_success'))
       setIsOpen(false)
+      onSuccess?.()
     },
     onError: () => {
       showErrorToast(tPattern('pattern_delete_error'))

--- a/frontend/src/components/Patterns/EditPattern.tsx
+++ b/frontend/src/components/Patterns/EditPattern.tsx
@@ -94,6 +94,7 @@ const EditPattern = ({ pattern, closeMenu }: EditPatternProps) => {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["patterns"] })
+      queryClient.invalidateQueries({ queryKey: ["pattern"] })
     },
   })
 

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as LayoutIndexImport } from './routes/_layout/index'
 import { Route as LayoutSettingsImport } from './routes/_layout/settings'
 import { Route as LayoutPatternsImport } from './routes/_layout/patterns'
 import { Route as LayoutAdminImport } from './routes/_layout/admin'
+import { Route as LayoutPatternsIdImport } from './routes/_layout/patterns_.$id'
 
 // Create/Update Routes
 
@@ -68,6 +69,11 @@ const LayoutAdminRoute = LayoutAdminImport.update({
   getParentRoute: () => LayoutRoute,
 } as any)
 
+const LayoutPatternsIdRoute = LayoutPatternsIdImport.update({
+  path: '/patterns/$id',
+  getParentRoute: () => LayoutRoute,
+} as any)
+
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
@@ -108,6 +114,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutIndexImport
       parentRoute: typeof LayoutImport
     }
+    '/_layout/patterns/$id': {
+      preLoaderRoute: typeof LayoutPatternsIdImport
+      parentRoute: typeof LayoutImport
+    }
   }
 }
 
@@ -119,6 +129,7 @@ export const routeTree = rootRoute.addChildren([
     LayoutPatternsRoute,
     LayoutSettingsRoute,
     LayoutIndexRoute,
+    LayoutPatternsIdRoute,
   ]),
   LoginRoute,
   RecoverPasswordRoute,

--- a/frontend/src/routes/_layout/patterns.tsx
+++ b/frontend/src/routes/_layout/patterns.tsx
@@ -7,7 +7,7 @@ import {
   Table,
   VStack,
   Image,
-  Badge, Spinner, Center
+  Badge, Spinner, Center, Text
 } from "@chakra-ui/react"
 import { useState, useEffect } from 'react';
 import { useQuery } from "@tanstack/react-query"
@@ -150,7 +150,15 @@ function PatternsTable() {
                 <IconImage filename={pattern.icon ?? ""} alt={pattern.title} />
               </Table.Cell>
               <Table.Cell truncate maxW="sm">
-                {pattern.title}
+                <Text
+                  as="span"
+                  cursor="pointer"
+                  color="teal.600"
+                  _hover={{ textDecoration: "underline" }}
+                  onClick={() => navigate({ to: "/patterns/$id", params: { id: pattern.id } })}
+                >
+                  {pattern.title}
+                </Text>
                 {currentUser?.id === pattern.owner_id && (
                   <Badge ml="1" colorScheme="teal">
                     {t('my_pattern')}

--- a/frontend/src/routes/_layout/patterns_.$id.tsx
+++ b/frontend/src/routes/_layout/patterns_.$id.tsx
@@ -1,0 +1,303 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Center,
+  Container,
+  Flex,
+  Grid,
+  GridItem,
+  Heading,
+  HStack,
+  Image,
+  Link,
+  Spinner,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
+import { useQuery } from "@tanstack/react-query"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { useEffect, useState, Suspense } from "react"
+import { FaArrowLeft, FaDownload, FaExternalLinkAlt, FaStar } from "react-icons/fa"
+import { saveAs } from "file-saver"
+import { useTranslation } from "react-i18next"
+
+import { PatternsService, OpenAPI } from "@/client"
+import { getHeaders } from "@/client/core/request"
+import type { PatternPublic } from "@/client"
+import useAuth from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
+import AddFiles from "@/components/Patterns/AddFiles"
+import EditPattern from "@/components/Patterns/EditPattern"
+import DeletePattern from "@/components/Patterns/DeletePattern"
+import placeholderImage from "/assets/images/favicon.webp"
+
+export const Route = createFileRoute("/_layout/patterns/$id")({
+  component: () => (
+    <Suspense fallback={<Center minH="100vh"><Spinner size="xl" /></Center>}>
+      <PatternDetail />
+    </Suspense>
+  ),
+})
+
+const FILE_KEYS: { key: keyof PatternPublic; labelKey: string }[] = [
+  { key: "pattern_a0_file_id", labelKey: "A0" },
+  { key: "pattern_a0_sa_file_id", labelKey: "A0 SA" },
+  { key: "pattern_a0_sa_projector_file_id", labelKey: "A0 SA Projector" },
+  { key: "pattern_a0_projector_file_id", labelKey: "A0 Projector" },
+  { key: "pattern_a4_file_id", labelKey: "A4" },
+  { key: "pattern_a4_sa_file_id", labelKey: "A4 SA" },
+  { key: "pattern_instructables_file_id", labelKey: "instructables_file" },
+]
+
+function PatternDetail() {
+  const { t } = useTranslation("pattern")
+  const { id } = Route.useParams()
+  const navigate = useNavigate()
+  const { user: currentUser } = useAuth()
+  const { showSuccessToast } = useCustomToast()
+
+  const { data: pattern, isLoading } = useQuery({
+    queryKey: ["pattern", id],
+    queryFn: () => PatternsService.readPattern({ id }),
+  })
+
+  const handleDownload = async (filename: string) => {
+    try {
+      const headers = await getHeaders(OpenAPI, {
+        method: "GET",
+        url: "/api/v1/patterns/download/{filename}",
+        path: { filename },
+      })
+      const baseUrl = OpenAPI.BASE
+      const response = await fetch(
+        `${baseUrl}/api/v1/patterns/download/${filename}`,
+        { method: "GET", headers },
+      )
+      if (!response.ok) throw new Error(t("download_failed"))
+      const blob = await response.blob()
+      saveAs(blob, filename)
+      showSuccessToast(t("file_downloaded"))
+    } catch (error) {
+      console.error(t("download_failed"), error)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <Center minH="100vh">
+        <Spinner size="xl" />
+      </Center>
+    )
+  }
+
+  if (!pattern) {
+    return (
+      <Container maxW="full" pt={12}>
+        <Text mb={4}>{t("pattern_not_found")}</Text>
+        <Button onClick={() => navigate({ to: "/patterns" })}>
+          <FaArrowLeft />
+          {t("back_to_patterns")}
+        </Button>
+      </Container>
+    )
+  }
+
+  const isOwnerOrAdmin =
+    currentUser?.is_superuser || currentUser?.id === pattern.owner_id
+
+  return (
+    <Container maxW="full">
+      <Flex justify="space-between" align="center" pt={12} mb={8}>
+        <Button variant="ghost" onClick={() => navigate({ to: "/patterns" })}>
+          <FaArrowLeft />
+          {t("back_to_patterns")}
+        </Button>
+        {isOwnerOrAdmin && (
+          <HStack>
+            <AddFiles id={pattern.id} />
+            <EditPattern pattern={pattern} />
+            <DeletePattern
+              id={pattern.id}
+              onSuccess={() => navigate({ to: "/patterns" })}
+            />
+          </HStack>
+        )}
+      </Flex>
+
+      <Grid
+        templateColumns={{ base: "1fr", md: "280px 1fr" }}
+        gap={8}
+        mb={10}
+      >
+        <GridItem>
+          <PatternImage filename={pattern.icon ?? ""} alt={pattern.title} />
+        </GridItem>
+        <GridItem>
+          <VStack align="start" gap={4}>
+            <HStack flexWrap="wrap">
+              <Heading size="xl">{pattern.title}</Heading>
+              {currentUser?.id === pattern.owner_id && (
+                <Badge colorScheme="teal">{t("my_pattern")}</Badge>
+              )}
+            </HStack>
+
+            {pattern.description && (
+              <Text color="gray.600">{pattern.description}</Text>
+            )}
+
+            <Grid
+              templateColumns="auto 1fr"
+              gap={3}
+              w="full"
+              alignItems="center"
+            >
+              <Text fontWeight="semibold">{t("brand")}:</Text>
+              <Text>
+                {pattern.brand === "Other" ? t("brand_null") : pattern.brand}
+              </Text>
+
+              <Text fontWeight="semibold">{t("version")}:</Text>
+              <Text>{t(`version_categories.${pattern.version}`)}</Text>
+
+              <Text fontWeight="semibold">{t("for_who")}:</Text>
+              <Text>{t(`for_who_categories.${pattern.for_who}`)}</Text>
+
+              {pattern.category && (
+                <>
+                  <Text fontWeight="semibold">{t("category")}:</Text>
+                  <Text>{t(`categories.${pattern.category}`)}</Text>
+                </>
+              )}
+
+              <Text fontWeight="semibold">{t("difficulty")}:</Text>
+              <HStack>
+                {Array.from({ length: 5 }, (_, i) => (
+                  <FaStar
+                    key={i}
+                    color={i < pattern.difficulty ? "gold" : "lightgray"}
+                  />
+                ))}
+              </HStack>
+
+              {pattern.fabric && (
+                <>
+                  <Text fontWeight="semibold">{t("fabric")}:</Text>
+                  <Text>{pattern.fabric}</Text>
+                </>
+              )}
+
+              {pattern.fabric_amount != null && (
+                <>
+                  <Text fontWeight="semibold">{t("min_fabric_amount")}:</Text>
+                  <Text>{pattern.fabric_amount}</Text>
+                </>
+              )}
+
+              {pattern.pattern_url && (
+                <>
+                  <Text fontWeight="semibold">{t("pattern_url")}:</Text>
+                  <Link
+                    href={pattern.pattern_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    color="teal.500"
+                  >
+                    <HStack display="inline-flex" gap={1}>
+                      <Text>{t("open_url")}</Text>
+                      <FaExternalLinkAlt size={12} />
+                    </HStack>
+                  </Link>
+                </>
+              )}
+            </Grid>
+          </VStack>
+        </GridItem>
+      </Grid>
+
+      <Box>
+        <Heading size="md" mb={4}>
+          {t("pattern_files")}
+        </Heading>
+        <Grid
+          templateColumns={{ base: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }}
+          gap={3}
+        >
+          {FILE_KEYS.map(({ key, labelKey }) => {
+            const fileId = pattern[key] as string | null | undefined
+            const label = key === "pattern_instructables_file_id"
+              ? t("instructables_file")
+              : labelKey
+            return (
+              <Flex
+                key={key}
+                justify="space-between"
+                align="center"
+                p={3}
+                borderWidth={1}
+                borderRadius="md"
+              >
+                <Text fontWeight="medium">{label}</Text>
+                {fileId ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleDownload(fileId)}
+                  >
+                    <FaDownload />
+                    {t("download")}
+                  </Button>
+                ) : (
+                  <Text fontStyle="italic" color="gray.500" fontSize="sm">
+                    {t("not_available")}
+                  </Text>
+                )}
+              </Flex>
+            )
+          })}
+        </Grid>
+      </Box>
+    </Container>
+  )
+}
+
+function PatternImage({ filename, alt }: { filename: string; alt: string }) {
+  const [imageUrl, setImageUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!filename) return
+    const fetchImage = async () => {
+      try {
+        const headers = await getHeaders(OpenAPI, {
+          method: "GET",
+          url: "/api/v1/patterns/download/{filename}",
+          path: { filename },
+        })
+        const baseUrl = OpenAPI.BASE
+        const response = await fetch(
+          `${baseUrl}/api/v1/patterns/download/${filename}`,
+          { method: "GET", headers },
+        )
+        if (!response.ok) throw new Error("Download failed")
+        const blob = await response.blob()
+        setImageUrl(URL.createObjectURL(blob))
+      } catch (error) {
+        console.error("Error loading image:", error)
+      }
+    }
+    fetchImage()
+  }, [filename])
+
+  return (
+    <Image
+      src={imageUrl || placeholderImage}
+      alt={alt}
+      w="full"
+      maxH="400px"
+      objectFit="contain"
+      borderRadius="md"
+      borderWidth={1}
+      p={2}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

- New route `/patterns/:id` with a full-page pattern detail view showing a large image, all metadata (brand, version, for who, category, difficulty stars, fabric, URL), and a file download grid for all 7 file variants
- Pattern titles in the list table are now clickable links that navigate to the detail view
- Owner/superuser actions (Add Files, Edit, Delete) shown in the detail header; Delete navigates back to the list on success
- Fixed query invalidation in `EditPattern` and `AddFiles` to also invalidate `["pattern"]` so the detail view auto-refreshes after edits/uploads without a manual page reload
- Replaced synchronous `getQueryData` with `useAuth()` in the detail page so owner actions render correctly on a hard refresh (F5)
- Added i18n keys (`back_to_patterns`, `pattern_not_found`, `open_url`) in EN and ES locales

## Test plan

- [x] Navigate to `/patterns`, click a pattern title → detail page opens
- [x] Verify large image, all metadata fields, and file download buttons render correctly
- [x] Download a file from the detail view
- [x] Edit the pattern from the detail view → dialog closes and detail updates automatically (no manual refresh)
- [x] Add files from the detail view → same auto-update behaviour
- [x] Delete the pattern from the detail view → navigates back to `/patterns`
- [x] Press F5 on the detail page while logged in as the owner → Add Files / Edit / Delete buttons are visible
- [x] Press F5 on the detail page while logged in as a non-owner → buttons are hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)