### PR TITLE
Improve README with project description, quick start, and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,123 @@
 # PatternLand
 
-## Acknowledgments
-This project mainly uses the following technologies and resources (among others):
-- **[Full Stack FastAPI Template](https://github.com/fastapi/full-stack-fastapi-template)**: A full-stack FastAPI template that inspired the initial development of this project and played a key role in my learning journey with FastAPI.
-- **[FastAPI](https://fastapi.tiangolo.com/)**: A modern, fast (high-performance), web framework for building APIs with Python based on standard Python type hints.
-- **[SQLModel](https://sqlmodel.tiangolo.com/)**: A modern Python library for interacting with databases, combining SQLAlchemy and Pydantic into one easy-to-use library.
-  - **[SQLAlchemy](https://www.sqlalchemy.org/)**: The core database toolkit and ORM used by SQLModel under the hood for handling database sessions and migrations.
-  - **[Pydantic](https://docs.pydantic.dev/latest//)**: Data validation and settings management using Python type annotations. Pydantic is integrated with SQLModel to simplify model validation.
+PatternLand is a self-hosted sewing pattern manager. Upload your paper and digital patterns, attach PDF files in multiple formats (A0, A4, projector-ready, with/without seam allowance), browse and filter your collection, and download any file at any time — all from a clean web interface.
 
+## Tech Stack
 
-Special thanks to all contributors of these open-source projects and all the libraries which are in use!
+| Layer | Technology |
+|---|---|
+| Frontend | React 18 + TypeScript, Vite, TanStack Router & Query, Chakra UI v3 |
+| Backend | FastAPI, SQLModel, Alembic, Pydantic, argon2-cffi (JWT auth) |
+| Database | PostgreSQL 17 |
+| Object storage | MinIO (S3-compatible) |
+| Proxy | Traefik |
+| Package managers | uv (Python), npm (Node) |
 
-## Configuration
+## Prerequisites
 
-## Secret key generation
-Generating a long, random secret key is crucial for security when using algorithms like HS256 in JWT. A strong key makes it difficult for attackers to guess or brute-force your secret.
+- [Docker](https://docs.docker.com/engine/install/) + Docker Compose v2
+- `python -c "import secrets; print(secrets.token_urlsafe(32))"` available for secret generation
 
-Here's how you can generate a secure, random secret key. Repeat it the for all the desired passwords:
+## Quick Start
+
+1. **Copy the example env file and fill in your secrets:**
+
+```bash
+cp my.env.example .env
+```
+
+Generate strong values for every field that says `changethis`:
+
 ```bash
 python -c "import secrets; print(secrets.token_urlsafe(32))"
 ```
+
+2. **Start the stack:**
+
+```bash
+docker compose watch
+```
+
+3. **Open the app:**
+
+| Service | URL |
+|---|---|
+| Frontend | http://localhost:5173 |
+| Backend API | http://localhost:8000 |
+| Interactive API docs | http://localhost:8000/docs |
+| Adminer (DB UI) | http://localhost:8080 |
+| MinIO console | http://localhost:9001 |
+| Traefik dashboard | http://localhost:8090 |
+| MailCatcher | http://localhost:1080 |
+
+Log in with the `FIRST_SUPERUSER` / `FIRST_SUPERUSER_PASSWORD` values from your `.env`.
+
+> The first startup may take a minute while the backend waits for the database and runs migrations.
+
+## Configuration
+
+All runtime configuration lives in a single `.env` file at the project root. Copy `my.env.example` to `.env` and set each value.
+
+Key variables:
+
+| Variable | Description |
+|---|---|
+| `SECRET_KEY` | JWT signing key — generate with `secrets.token_urlsafe(32)` |
+| `FIRST_SUPERUSER` | Email of the initial admin user |
+| `FIRST_SUPERUSER_PASSWORD` | Password of the initial admin user |
+| `POSTGRES_PASSWORD` | PostgreSQL password |
+| `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` | MinIO admin credentials |
+| `S3_ACCESS_KEY` / `S3_SECRET_KEY` | MinIO bucket access credentials |
+| `DOMAIN` | Base domain (`localhost` for local dev) |
+| `ENVIRONMENT` | `local`, `staging`, or `production` |
+
+See `my.env.example` for the full list.
+
+## Development
+
+For running individual services locally (outside Docker) or working with pre-commit hooks, see **[development.md](./development.md)**.
+
+## Deployment
+
+For production deployment with Traefik, TLS certificates, and GitHub Actions CI/CD, see **[deployment.md](./deployment.md)**.
+
+## Project Structure
+
+```
+patternland/
+├── backend/          # FastAPI application (Python, uv)
+│   ├── app/
+│   │   ├── api/      # Route handlers
+│   │   ├── models/   # SQLModel database models
+│   │   └── tests/    # Pytest test suite
+│   └── pyproject.toml
+├── frontend/         # React application (TypeScript, npm)
+│   ├── src/
+│   │   ├── client/   # Auto-generated OpenAPI client
+│   │   ├── components/
+│   │   └── routes/   # TanStack file-based routes
+│   └── package.json
+├── docker-compose.yaml
+├── docker-compose.override.yaml   # Local dev overrides
+├── my.env.example
+└── .env                           # Your local config (not committed)
+```
+
 ## Release Notes
 
-Check the file [release-notes.md](./release-notes.md).
+See [release-notes.md](./release-notes.md).
+
+## Security
+
+See [SECURITY.md](./SECURITY.md) for the vulnerability reporting policy.
+
+## Acknowledgments
+
+- **[Full Stack FastAPI Template](https://github.com/fastapi/full-stack-fastapi-template)** — inspired the initial project structure and was a key learning resource.
+- **[FastAPI](https://fastapi.tiangolo.com/)** — high-performance Python web framework.
+- **[SQLModel](https://sqlmodel.tiangolo.com/)** — combines SQLAlchemy and Pydantic for clean database models.
+
+Thanks to all contributors of these open-source projects and every library used in this project!
 
 ## License
 


### PR DESCRIPTION
## Summary

Rewrites the README from a minimal acknowledgments page into a proper project document:

- **Project description** — one-paragraph summary of what PatternLand does
- **Tech stack table** — frontend, backend, database, storage, proxy at a glance
- **Quick start** — copy env → fill secrets → `docker compose watch`, with a URL table for all services
- **Configuration table** — key env vars explained, pointer to `my.env.example` for the full list
- **Development / Deployment** — short sections delegating to the existing `development.md` and `deployment.md`
- **Project structure** — directory tree so contributors know where to look
- **Security & Release notes** — surfaced as first-class sections with links
- Kept Acknowledgments and License; moved the secret-key generation snippet into Quick Start where it's actually needed

## Test plan

- [x] README renders correctly on GitHub (tables, code blocks, links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)