### PR TITLE
feat: add collapsible desktop sidebar

### DIFF
--- a/frontend/src/components/Common/Sidebar.tsx
+++ b/frontend/src/components/Common/Sidebar.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, IconButton, Text, Spinner, Center } from "@chakra-ui/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { useState, Suspense } from "react"
 import { FaBars } from "react-icons/fa"
-import { FiLogOut } from "react-icons/fi"
+import { FiLogOut, FiChevronLeft, FiChevronRight } from "react-icons/fi"
 
 import type { UserPublic } from "@/client"
 import useAuth from "@/hooks/useAuth"
@@ -40,6 +40,7 @@ const SidebarContent = () => {
   const currentUser = queryClient.getQueryData<UserPublic>(["currentUser"])
   const { logout } = useAuth()
   const [open, setOpen] = useState(false)
+  const [isCollapsed, setIsCollapsed] = useState(false)
 
   return (
     <>
@@ -98,15 +99,28 @@ const SidebarContent = () => {
 
       <Box
         display={{ base: "none", md: "flex" }}
+        flexDirection="column"
         position="sticky"
         bg="bg.subtle"
         top={0}
-        minW="xxs"
+        w={isCollapsed ? "16" : "52"}
         h="100vh"
         p={4}
+        transition="width 0.2s ease"
+        overflow="hidden"
       >
+        <Flex justify={isCollapsed ? "center" : "flex-end"} mb={2}>
+          <IconButton
+            aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            variant="ghost"
+            size="sm"
+            onClick={() => setIsCollapsed(!isCollapsed)}
+          >
+            {isCollapsed ? <FiChevronRight /> : <FiChevronLeft />}
+          </IconButton>
+        </Flex>
         <Box w="100%">
-          <SidebarItems />
+          <SidebarItems isCollapsed={isCollapsed} />
         </Box>
       </Box>
     </>

--- a/frontend/src/components/Common/SidebarItems.tsx
+++ b/frontend/src/components/Common/SidebarItems.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Icon, Text } from "@chakra-ui/react"
+import { Box, Flex, Icon, Text, Tooltip } from "@chakra-ui/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { Link as RouterLink } from "@tanstack/react-router"
 import { FiHome, FiSettings, FiUsers } from "react-icons/fi"
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 interface SidebarItemsProps {
   onClose?: () => void
+  isCollapsed?: boolean
 }
 
 interface Item {
@@ -19,7 +20,7 @@ interface Item {
   path: string
 }
 
-const SidebarItems = ({ onClose }: SidebarItemsProps) => {
+const SidebarItems = ({ onClose, isCollapsed }: SidebarItemsProps) => {
   const { t: tAdmin } = useTranslation('admin'); // 👈 tells i18next to use "admin.json"
   const { t: tPattern } = useTranslation('pattern'); // 👈 tells i18next to use "common.json"
   const items = [
@@ -34,29 +35,45 @@ const SidebarItems = ({ onClose }: SidebarItemsProps) => {
     ? [...items, { icon: FiUsers, title: "Admin", path: "/admin" }]
     : items
 
-  const listItems = finalItems.map(({ icon, title, path }) => (
-    <RouterLink key={title} to={path} onClick={onClose}>
+  const listItems = finalItems.map(({ icon, title, path }) => {
+    const itemFlex = (
       <Flex
-        gap={4}
+        gap={isCollapsed ? 0 : 4}
         px={4}
         py={2}
-        _hover={{
-          background: "gray.subtle",
-        }}
+        _hover={{ background: "gray.subtle" }}
         alignItems="center"
+        justifyContent={isCollapsed ? "center" : "flex-start"}
         fontSize="md"
       >
         <Icon as={icon} alignSelf="center" boxSize={6} />
-        <Text ml={2}>{title}</Text>
+        {!isCollapsed && <Text ml={2}>{title}</Text>}
       </Flex>
-    </RouterLink>
-  ))
+    )
+
+    return (
+      <RouterLink key={title} to={path} onClick={onClose}>
+        {isCollapsed ? (
+          <Tooltip.Root positioning={{ placement: "right" }}>
+            <Tooltip.Trigger asChild>{itemFlex}</Tooltip.Trigger>
+            <Tooltip.Positioner>
+              <Tooltip.Content>{title}</Tooltip.Content>
+            </Tooltip.Positioner>
+          </Tooltip.Root>
+        ) : (
+          itemFlex
+        )}
+      </RouterLink>
+    )
+  })
 
   return (
     <>
-      <Text fontSize="md" px={4} py={2} fontWeight="bold">
-        Menu
-      </Text>
+      {!isCollapsed && (
+        <Text fontSize="md" px={4} py={2} fontWeight="bold">
+          Menu
+        </Text>
+      )}
       <Box>{listItems}</Box>
     </>
   )


### PR DESCRIPTION
## Summary

- Adds a chevron toggle button at the top of the desktop sidebar to collapse/expand it
- Collapsed state shows icons only (64px wide) with smooth CSS width transition; expanded shows icons + labels (208px)
- Tooltips appear on icon hover in collapsed mode so navigation labels remain discoverable
- "Menu" heading is hidden when collapsed
- Mobile hamburger drawer behaviour is completely unchanged

## Test plan

- [x] On desktop (≥ md breakpoint): confirm sidebar shows full labels and a left-chevron button at the top
- [x] Click the chevron — sidebar animates to icon-only width, labels disappear, chevron flips to right
- [x] Hover over an icon in collapsed state — tooltip with the item name appears on the right
- [x] Click the chevron again — sidebar expands back with labels
- [x] Navigate between routes while collapsed — routing works correctly
- [x] On mobile: confirm hamburger drawer behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)